### PR TITLE
Harden Maven Central metadata checks in octopus-parent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Maven Compile & UT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   run-build-and-deploy:

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,53 @@
                                 </rules>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>require-central-metadata</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireProperty>
+                                        <property>project.name</property>
+                                        <message>Maven Central requires project.name</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.description</property>
+                                        <message>Maven Central requires project.description</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.url</property>
+                                        <message>Maven Central requires project.url</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.licenses[0].name</property>
+                                        <message>Maven Central requires at least one license name</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.licenses[0].url</property>
+                                        <message>Maven Central requires at least one license url</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.developers[0].name</property>
+                                        <message>Maven Central requires at least one developer name</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.scm.connection</property>
+                                        <message>Maven Central requires project.scm.connection</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.scm.developerConnection</property>
+                                        <message>Maven Central requires project.scm.developerConnection</message>
+                                    </requireProperty>
+                                    <requireProperty>
+                                        <property>project.scm.url</property>
+                                        <message>Maven Central requires project.scm.url</message>
+                                    </requireProperty>
+                                </rules>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -164,6 +211,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
         <maven-pmd-plugin.version>3.19.0</maven-pmd-plugin.version>
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -109,8 +109,8 @@
                             <configuration>
                                 <rules>
                                     <requireProperty>
-                                        <property>project.name</property>
-                                        <message>Maven Central requires project.name</message>
+                                        <property>project.model.name</property>
+                                        <message>Maven Central requires explicit &lt;name&gt; in pom.xml</message>
                                     </requireProperty>
                                     <requireProperty>
                                         <property>project.description</property>


### PR DESCRIPTION
## Summary
- enforce Maven Central-required metadata in `validate` via `maven-enforcer-plugin`
- require explicit `<name>` via `project.model.name` (prevents Maven fallback to `artifactId`)
- keep required checks for:
  - `project.description`
  - `project.url`
  - `project.licenses[0].name`
  - `project.licenses[0].url`
  - `project.developers[0].name`
  - `project.scm.connection`
  - `project.scm.developerConnection`
  - `project.scm.url`
- run these checks in child projects by including `maven-enforcer-plugin` in `<build><plugins>`
- update Enforcer version to `3.6.2`
- avoid duplicate CI runs for PR branches by running `push` workflow only on `main`

## Validation
- `mvn -q validate` in `octopus-parent`
- smoke test with temporary child POMs:
  - missing `<name>` -> fails with `Maven Central requires explicit <name> in pom.xml`
  - explicit `<name>` -> passes

## Notes
- this removes the need for ad-hoc Python POM validation scripts for these metadata checks
